### PR TITLE
chore: Upgrade ESLint and Prettier configurations

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,0 @@
-node_modules/
-coverage/

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,4 +1,0 @@
-module.exports = {
-  extends: ['plugin:@sektek/typescript'],
-  rules: {},
-};

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,1 +1,0 @@
-module.exports = require('@sektek/prettier-config');

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+import prettierConfig from '@sektek/prettier-config';
+
+export default prettierConfig;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'eslint/config';
+import sektek from '@sektek/eslint-plugin';
+
+export default defineConfig([
+  sektek.configs.typescript,
+  {
+    rules: {},
+  },
+]);

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@sektek/eslint-plugin": "1.0.1",
-    "@sektek/prettier-config": "1.1.3",
+    "@sektek/eslint-plugin": "^2.0.0",
+    "@sektek/prettier-config": "^2.0.0",
     "@types/chai": "^5.0.1",
     "@types/chai-as-promised": "^8.0.1",
     "@types/express": "^5.0.0",
@@ -36,9 +36,9 @@
     "@types/supertest": "^6.0.2",
     "c8": "^10.1.3",
     "chai": "^5.1.2",
-    "eslint": "^8.57.0",
+    "eslint": "^9.39.1",
     "mocha": "^10.8.2",
-    "prettier": "^3.2.5",
+    "prettier": "^3.4.1",
     "sinon": "^19.0.2",
     "sinon-chai": "^4.0.0",
     "supertest": "^7.0.0",

--- a/src/default-event-extractor.ts
+++ b/src/default-event-extractor.ts
@@ -7,9 +7,9 @@ export type DefaultEventExtractorOptions<T extends Event = Event> = {
   eventBuilder?: EventBuilder<T>;
 };
 
-export class DefaultEventExtractor<T extends Event = Event>
-  implements RequestEventExtractor<T>
-{
+export class DefaultEventExtractor<
+  T extends Event = Event,
+> implements RequestEventExtractor<T> {
   #eventBuilder: EventBuilder<T>;
 
   constructor(opts: DefaultEventExtractorOptions<T> = {}) {

--- a/src/http-gateway.spec.ts
+++ b/src/http-gateway.spec.ts
@@ -68,6 +68,7 @@ describe('HttpGateway', function () {
       expect(responseHandler).to.have.been.calledOnceWith(
         event,
         result,
+        // eslint-disable-next-line sonarjs/no-same-argument-assert
         match.any,
         match.any,
       );
@@ -115,8 +116,9 @@ describe('HttpGateway', function () {
     });
 
     it('should emit an event:error event if an error occurs after the event is extracted', async function () {
+      const error = new Error('error');
       const event = await new EventBuilder().create();
-      const handler = fake.throws(new Error('error'));
+      const handler = fake.throws(error);
       const gateway = new HttpGateway({ handler });
       this.app.post('/', gateway.requestHandler);
 
@@ -125,15 +127,13 @@ describe('HttpGateway', function () {
 
       await request(this.app).post('/').send(event).expect(500);
 
-      expect(listener).to.have.been.calledOnceWith(
-        event,
-        match.instanceOf(Error),
-      );
+      expect(listener).to.have.been.calledOnceWith(error, event);
     });
 
     it('should emit a request:error event if an error occurs', async function () {
+      const error = new Error('error');
       const event = await new EventBuilder().create();
-      const eventExtractor = fake.throws(new Error('error'));
+      const eventExtractor = fake.throws(error);
       const gateway = new HttpGateway({ handler: fake(), eventExtractor });
       this.app.post('/', gateway.requestHandler);
 
@@ -142,7 +142,7 @@ describe('HttpGateway', function () {
 
       await request(this.app).post('/').send(event).expect(500);
 
-      expect(listener).to.have.been.calledOnce;
+      expect(listener).to.have.been.calledOnceWith(error, match.any);
     });
 
     it('should emit a response:sent event after the response is sent', async function () {

--- a/src/http-gateway.ts
+++ b/src/http-gateway.ts
@@ -1,5 +1,8 @@
 import {
   AbstractEventService,
+  EVENT_ERROR,
+  EVENT_PROCESSED,
+  EVENT_RECEIVED,
   Event,
   EventHandlerFn,
   EventHandlerReturnType,
@@ -27,9 +30,9 @@ export type HttpGatewayOptions<
 };
 
 export class HttpGateway<
-    T extends Event = Event,
-    R extends EventHandlerReturnType = unknown,
-  >
+  T extends Event = Event,
+  R extends EventHandlerReturnType = unknown,
+>
   extends AbstractEventService
   implements HttpEventHandlingService<T, R>
 {
@@ -64,10 +67,10 @@ export class HttpGateway<
       this.emit('request:received', request);
 
       event = await this.#eventExtractor(request);
-      this.emit('event:received', event);
+      this.emit(EVENT_RECEIVED, event);
 
       const result = await this.#handler(event);
-      this.emit('event:processed', event, result);
+      this.emit(EVENT_PROCESSED, event, result);
 
       response.on('finish', () => {
         this.emit('response:sent', response);
@@ -76,9 +79,9 @@ export class HttpGateway<
       await this.#responseHandler(event, result, request, response);
     } catch (err) {
       if (event) {
-        this.emit('event:error', event, err);
+        this.emit(EVENT_ERROR, err, event);
       }
-      this.emit('request:error', request, err);
+      this.emit('request:error', err, request);
       if (next) {
         next(err);
       } else {

--- a/src/types/http-event-handling-service.ts
+++ b/src/types/http-event-handling-service.ts
@@ -1,10 +1,10 @@
+import { ErrorHandlerFn, EventEmittingService } from '@sektek/utility-belt';
 import {
   Event,
   EventHandlerEvents,
   EventHandlerReturnType,
 } from '@sektek/synaptik';
 import { NextFunction, Request, Response } from 'express';
-import { EventEmittingService } from '@sektek/utility-belt';
 
 export type HttpEventHandlingServiceEvents<
   T extends Event = Event,
@@ -12,7 +12,7 @@ export type HttpEventHandlingServiceEvents<
 > = EventHandlerEvents<T, R> & {
   'request:received': (request: Request) => void;
   'response:sent': (response: Response) => void;
-  'request:error': (request: Request, error: Error) => void;
+  'request:error': ErrorHandlerFn<Request>;
 };
 
 export interface HttpEventHandlingService<


### PR DESCRIPTION
Update ESLint and Prettier configurations to the latest versions, remove outdated config files, and apply lint fixes throughout the codebase.